### PR TITLE
* fix reconnect after server shutdown

### DIFF
--- a/lib/Mango.pm
+++ b/lib/Mango.pm
@@ -235,10 +235,11 @@ sub _next {
   push @{$self->{queue} ||= []}, $op if $op;
   my $connections = $self->{connections};
   my $start;
-  $self->_write($_) and $start++ for my @ids = keys %$connections;
+  $self->_write($_) and $start++ for keys %$connections;
 
   # Check if we need a blocking connection
   return unless $op;
+  my @ids = keys %$connections;
   return $self->_connect(0)
     if !$op->{nb} && !grep { !$connections->{$_}{nb} } @ids;
 


### PR DESCRIPTION
@ids were stored before _write, connection may be deleted inside _write, then $connections->{$_}{nb} in grep creates empty hash in $self->{conncections}
