### PR TITLE
Fix to_datetime() for datetimes before the epoch 

### DIFF
--- a/lib/Mango/BSON/Time.pm
+++ b/lib/Mango/BSON/Time.pm
@@ -9,7 +9,7 @@ sub new { shift->SUPER::new(time => shift // int(time * 1000)) }
 
 sub TO_JSON { 0 + shift->{time} }
 
-sub to_datetime { Mojo::Date->new(shift->to_epoch)->to_datetime }
+sub to_datetime { Mojo::Date->new->epoch(shift->to_epoch)->to_datetime }
 
 sub to_epoch { shift->to_string / 1000 }
 

--- a/t/bson.t
+++ b/t/bson.t
@@ -58,6 +58,10 @@ is bson_time(1360626536748), 1360626536748, 'right epoch milliseconds';
 is bson_time(1360626536748)->to_epoch, 1360626536.748, 'right epoch seconds';
 is bson_time(1360626536748)->to_datetime, '2013-02-11T23:48:56.748Z',
   'right format';
+is bson_time(-28731600 * 1000)->to_datetime, '1969-02-02T11:00:00Z',
+  'Before epoch: Boris Karloff death';
+is bson_time(-4890694522 * 1000)->to_datetime, '1815-01-08T17:44:38Z',
+  'Well before epoch: Battle of New Orleans';
 
 # Empty document
 my $bson = bson_encode {};


### PR DESCRIPTION

I found the issue when representing birth dates with Mango::Time objects - calling `to_datetime` on a date before the epoch like 1965-12-21 would emit uninit warnings and end up with Jan 1, 1970 as output. 

The bug comes from 

https://github.com/oliwer/mango/blob/master/lib/Mango/BSON/Time.pm#L12 which in turn points 

to Mojo::Date code 

https://github.com/kraih/mojo/blob/master/lib/Mojo/Date.pm#L25

I tried to fix the issue downstream in Mojo::Date

* https://github.com/kraih/mojo/pull/1079

* https://github.com/kraih/mojo/pull/1080

but those patches have been rejected: the first due to failing extra tests added for negative fractional epoch, and the second because it was not elegant enough.

This time, this patch is meant to make `Mango::BSON::Time` to replace `Mojo::Date->new($epoch)` (which does not work for dates before Jan 1, 1970) with `Mojo::Date->new->epoch($epoch)`.