### PR TITLE
Mango with promises

### DIFF
--- a/lib/Mango.pm
+++ b/lib/Mango.pm
@@ -410,6 +410,13 @@ you can use to generate data types that are not available natively in Perl.
 All connections will be reset automatically if a new process has been forked,
 this allows multiple processes to share the same L<Mango> object safely.
 
+Since version 1.31, L<Mango> supports non-blocking with promise-returning
+methods like
+L<< $collection->find_one_p|Mango::Collection/"find_one_p" >>,
+L<< $cursor->all_p|Mango::Cursor/"all_p" >>,
+L<< $bulk->execute_p|Mango::Bulk/"execute_p" >>, etc.
+Note that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 For better scalability (epoll, kqueue) and to provide IPv6, SOCKS5 as well as
 TLS support, the optional modules L<EV> (4.0+), L<IO::Socket::IP> (0.20+),
 L<IO::Socket::Socks> (0.64+) and L<IO::Socket::SSL> (1.84+) will be used
@@ -558,6 +565,15 @@ perform operation non-blocking.
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 get_more_p
+
+  my $promise = $mango->get_more_p($namespace, $return, $cursor);
+
+Same as L</"get_more">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 kill_cursors
 
   $mango->kill_cursors(@ids);
@@ -570,6 +586,15 @@ perform operation non-blocking.
       ...
     });
     Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
+
+=head2 kill_cursors_p
+
+  my $promise = $mango->kill_cursors_p(@ids);
+
+Same as L</"kill_cursors">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
 
 =head2 new
 
@@ -610,6 +635,16 @@ perform operation non-blocking.
     ...
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
+
+=head2 query_p
+
+  my $promise
+    = $mango->query_p($namespace, $flags, $skip, $return, $query, $fields);
+
+Same as L</"query">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
 
 =head1 DEBUGGING
 

--- a/lib/Mango.pm
+++ b/lib/Mango.pm
@@ -5,6 +5,7 @@ use Carp 'croak';
 use Hash::Util::FieldHash;
 use Mango::BSON 'bson_doc';
 use Mango::Database;
+use Mango::Promises;
 use Mango::Protocol;
 use Mojo::IOLoop;
 use Mojo::URL;
@@ -13,6 +14,7 @@ use Scalar::Util 'weaken';
 
 use constant DEBUG => $ENV{MANGO_DEBUG} || 0;
 use constant DEFAULT_PORT => 27017;
+use constant PROMISES => Mango::Promises::PROMISES;
 
 has connect_opt => sub { [] };
 has default_db  => 'admin';
@@ -30,6 +32,8 @@ has w => 1;
 Hash::Util::FieldHash::fieldhash my %AUTH;
 
 our $VERSION = '1.30';
+
+Mango::Promises->generate_p_methods(qw(get_more kill_cursors/0 query));
 
 sub DESTROY { shift->_cleanup }
 

--- a/lib/Mango/Bulk.pm
+++ b/lib/Mango/Bulk.pm
@@ -3,10 +3,13 @@ use Mojo::Base -base;
 
 use Carp 'croak';
 use Mango::BSON qw(bson_doc bson_encode bson_oid bson_raw);
+use Mango::Promises;
 use Mojo::IOLoop;
 
 has 'collection';
 has ordered => 1;
+
+Mango::Promises->generate_p_methods(qw(execute));
 
 sub execute {
   my ($self, $cb) = @_;

--- a/lib/Mango/Bulk.pm
+++ b/lib/Mango/Bulk.pm
@@ -212,6 +212,15 @@ non-blocking.
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 execute_p
+
+  my $promise = $bulk->execute_p;
+
+Same as L</"execute">, but performs bulk operations non-blocking
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 find
 
   $bulk = $bulk->find({foo => 'bar'});

--- a/lib/Mango/Collection.pm
+++ b/lib/Mango/Collection.pm
@@ -334,6 +334,15 @@ operation non-blocking.
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 aggregate_p
+
+  my $promise = $collection->aggregate_p(\@pipeline);
+
+Same as L</"aggregate">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 build_index_name
 
   my $name = $collection->build_index_name(bson_doc(foo => 1, bar => -1));
@@ -368,6 +377,16 @@ non-blocking.
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 create_p
+
+  my $promise = $collection->create_p;
+  my $promise = $collection->create_p(\%opts);
+
+Same as L</"create">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 drop
 
   $collection->drop;
@@ -381,6 +400,15 @@ non-blocking.
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 drop_p
+
+  my $promise = $collection->drop_p;
+
+Same as L</"drop">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 drop_index
 
   $collection->drop_index('foo');
@@ -392,6 +420,15 @@ Drop index. You can also append a callback to perform operation non-blocking.
     ...
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
+
+=head2 drop_index_p
+
+  my $promise = $collection->drop_index_p;
+
+Same as L</"drop_index">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
 
 =head2 ensure_index
 
@@ -408,6 +445,17 @@ append a callback to perform operation non-blocking.
     ...
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
+
+=head2 ensure_index_p
+
+  $promise = $collection->ensure_index_p(bson_doc(foo => 1, bar => -1));
+  $promise = $collection->ensure_index_p({foo => 1});
+  $promise = $collection->ensure_index_p({foo => 1}, {unique => bson_true});
+
+Same as L</"ensure_index">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
 
 =head2 find
 
@@ -438,6 +486,15 @@ to perform operation non-blocking.
 By default this method returns the unmodified version of the document. To
 change this behaviour, add the option C<new =E<gt> 1>.
 
+=head2 find_and_modify_p
+
+  $promise = $collection->find_and_modify_p($opts);
+
+Same as L</"find_and_modify">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 find_one
 
   my $doc = $collection->find_one({foo => 'bar'});
@@ -452,6 +509,17 @@ non-blocking.
     ...
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
+
+=head2 find_one_p
+
+  my $promise = $collection->find_one_p({foo => 'bar'});
+  my $promise = $collection->find_one_p({foo => 'bar'}, {foo => 1});
+  my $promise = $collection->find_one_p($oid, {foo => 1});
+
+Same as L</"find_one">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
 
 =head2 full_name
 
@@ -474,6 +542,16 @@ perform operation non-blocking.
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 index_information_p
+
+  my $promise = $collection->index_information_p;
+  my $promise = $collection->index_information_p(cursor => { batchSize => 5 });
+
+Same as L</"index_information">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 insert
 
   my $oid  = $collection->insert({foo => 'bar'});
@@ -493,6 +571,16 @@ them to MongoDB. To avoid modifying your data, it makes a copy of the
 documents. This can be a bit slow if you are sending big objects like
 pictures. To avoid that, consider using C<save> instead.
 
+=head2 insert_p
+
+  my $promise = $collection->insert_p({foo => 'bar'});
+  my $promise = $collection->insert_p([{foo => 'bar'}, {baz => 'yada'}]);
+
+Same as L</"insert_p">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 map_reduce
 
   my $collection = $collection->map_reduce($map, $reduce, {out => 'foo'});
@@ -511,6 +599,18 @@ operation non-blocking.
   );
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 map_reduce_p
+
+  my $promise = $collection->map_reduce_p($map, $reduce, {out => 'foo'});
+  my $promise = $collection->map_reduce_p($map, $reduce, {out => {inline => 1}});
+  my $promise = $collection->map_reduce_p(
+    bson_code($map), bson_code($reduce), {out => {inline => 1}});
+
+Same as L</"map_reduce">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 options
 
   my $doc = $collection->options;
@@ -523,6 +623,15 @@ operation non-blocking.
     ...
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
+
+=head2 options_p
+
+  my $promise = $collection->options_p;
+
+Same as L</"options">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
 
 =head2 remove
 
@@ -552,6 +661,18 @@ Remove only one document.
 
 =back
 
+=head2 remove_p
+
+  my $promise = $collection->remove_p;
+  my $promise = $collection->remove_p($oid);
+  my $promise = $collection->remove_p({foo => 'bar'});
+  my $promise = $collection->remove_p({foo => 'bar'}, {single => 1});
+
+Same as L</"remove">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 rename
 
   my $new_collection = $collection->rename('NewName');
@@ -566,6 +687,15 @@ also append a callback to perform operation non-blocking.
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 rename_p
+
+  my $promise = $collection->rename_p('NewName');
+
+Same as L</"rename">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 save
 
   my $oid = $collection->save({foo => 'bar'});
@@ -579,6 +709,15 @@ append a callback to perform operation non-blocking.
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 save_p
+
+  my $promise = $collection->save_p({foo => 'bar'});
+
+Same as L</"save">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 stats
 
   my $stats = $collection->stats;
@@ -591,6 +730,15 @@ non-blocking.
     ...
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
+
+=head2 stats_p
+
+  my $promise = $collection->stats_p;
+
+Same as L</"stats">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
 
 =head2 update
 
@@ -624,6 +772,17 @@ Update more than one document.
 Insert document if none could be updated.
 
 =back
+
+=head2 update_p
+
+  my $promise = $collection->update_p($oid, {foo => 'baz'});
+  my $promise = $collection->update_p({foo => 'bar'}, {foo => 'baz'});
+  my $promise = $collection->update_p({foo => 'bar'}, {foo => 'baz'}, {multi => 1});
+
+Same as L</"update">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
 
 =head1 SEE ALSO
 

--- a/lib/Mango/Collection.pm
+++ b/lib/Mango/Collection.pm
@@ -6,8 +6,14 @@ use Mango::BSON qw(bson_code bson_doc bson_oid);
 use Mango::Bulk;
 use Mango::Cursor;
 use Mango::Cursor::Query;
+use Mango::Promises;
 
 has [qw(db name)];
+
+Mango::Promises->generate_p_methods(
+  qw(aggregate create/0 drop/0 drop_index/0 ensure_index/0 find_and_modify find_one
+    index_information insert map_reduce options remove rename save stats update)
+);
 
 sub aggregate {
   my ($self, $pipeline) = (shift, shift);

--- a/lib/Mango/Cursor.pm
+++ b/lib/Mango/Cursor.pm
@@ -1,10 +1,13 @@
 package Mango::Cursor;
 use Mojo::Base -base;
 
+use Mango::Promises;
 use Mojo::IOLoop;
 
 has [qw(collection id ns)];
 has [qw(batch_size limit)] => 0;
+
+Mango::Promises->generate_p_methods(qw(all next rewind/0));
 
 sub add_batch {
   my ($self, $docs) = @_;

--- a/lib/Mango/Cursor.pm
+++ b/lib/Mango/Cursor.pm
@@ -188,6 +188,15 @@ operation non-blocking.
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 all_p
+
+  my $promise = $cursor->all_p;
+
+Same as L</"all">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 next
 
   my $doc = $cursor->next;
@@ -201,6 +210,15 @@ non-blocking.
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 next_p
+
+  my $promise = $cursor->next_p;
+
+Same as L</"next">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 rewind
 
   $cursor->rewind;
@@ -213,6 +231,15 @@ perform operation non-blocking.
     ...
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
+
+=head2 rewind_p
+
+  my $promise = $cursor->rewind_p;
+
+Same as L</"rewind">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
 
 =head2 num_to_return
 

--- a/lib/Mango/Cursor/Query.pm
+++ b/lib/Mango/Cursor/Query.pm
@@ -2,6 +2,7 @@ package Mango::Cursor::Query;
 use Mojo::Base 'Mango::Cursor';
 
 use Mango::BSON 'bson_doc';
+use Mango::Promises;
 
 has [
   qw(await_data comment hint max_scan max_time_ms read_preference snapshot),
@@ -9,6 +10,8 @@ has [
 ];
 has [qw(fields query)];
 has skip => 0;
+
+Mango::Promises->generate_p_methods(qw(count distinct explain));
 
 sub build_query {
   my ($self, $explain) = @_;

--- a/lib/Mango/Cursor/Query.pm
+++ b/lib/Mango/Cursor/Query.pm
@@ -256,6 +256,15 @@ callback to perform operation non-blocking.
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 count_p
+
+  my $promise = $cursor->count_p;
+
+Same as L</"count">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 distinct
 
   my $values = $cursor->distinct('foo');
@@ -269,6 +278,15 @@ operation non-blocking.
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 distinct_p
+
+  my $promise = $cursor->distinct_p('foo');
+
+Same as L</"distinct">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 explain
 
   my $doc = $cursor->explain;
@@ -281,6 +299,15 @@ perform operation non-blocking.
     ...
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
+
+=head2 explain_p
+
+  my $promise = $cursor->explain_p;
+
+Same as L</"explain">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
 
 =head1 SEE ALSO
 

--- a/lib/Mango/Database.pm
+++ b/lib/Mango/Database.pm
@@ -179,6 +179,15 @@ to perform operation non-blocking.
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 collection_names_p
+
+  my $promise = $db->collection_names_p;
+
+Same as L</"collection_names">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 command
 
   my $doc = $db->command(bson_doc(text => 'foo.bar', search => 'test'));
@@ -194,6 +203,17 @@ non-blocking.
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 command_p
+
+  my $promise = $db->command_p(bson_doc(text => 'foo.bar', search => 'test'));
+  my $promise = $db->command_p(bson_doc(getLastError => 1, w => 2));
+  my $promise = $db->command_p('getLastError', w => 2);
+
+Same as L</"command">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 dereference
 
   my $doc = $db->dereference($dbref);
@@ -206,6 +226,15 @@ operation non-blocking.
     ...
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
+
+=head2 dereference_p
+
+  my $promise = $db->dereference_p($dbref);
+
+Same as L</"dereference">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
 
 =head2 gridfs
 
@@ -234,6 +263,18 @@ C<options>. You can also append a callback to perform operation non-blocking.
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 list_collections_p
+
+  my $promise = $db->list_collections_p;
+  my $promise = $db->list_collections_p(filter => { name => qr{^prefix} });
+  my $promise = $db->list_collections_p(filter => { 'options.capped' => 1 });
+  my $promise = $db->list_collections_p(cursor => { batchSize => 10 });
+
+Same as L</"list_collections">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 stats
 
   my $stats = $db->stats;
@@ -246,6 +287,15 @@ non-blocking.
     ...
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
+
+=head2 stats_p
+
+  my $promise = $db->stats_p;
+
+Same as L</"stats">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
 
 =head1 SEE ALSO
 

--- a/lib/Mango/Database.pm
+++ b/lib/Mango/Database.pm
@@ -5,8 +5,12 @@ use Carp 'croak';
 use Mango::BSON qw(bson_code bson_doc);
 use Mango::Collection;
 use Mango::GridFS;
+use Mango::Promises;
 
 has [qw(mango name)];
+
+Mango::Promises->generate_p_methods(
+  qw(collection_names command dereference list_collections stats));
 
 sub build_write_concern {
   my $mango = shift->mango;

--- a/lib/Mango/GridFS.pm
+++ b/lib/Mango/GridFS.pm
@@ -3,11 +3,14 @@ use Mojo::Base -base;
 
 use Mango::GridFS::Reader;
 use Mango::GridFS::Writer;
+use Mango::Promises;
 
 has chunks => sub { $_[0]->db->collection($_[0]->prefix . '.chunks') };
 has 'db';
 has files => sub { $_[0]->db->collection($_[0]->prefix . '.files') };
 has prefix => 'fs';
+
+Mango::Promises->generate_p_methods(qw(delete/0 find_version list));
 
 sub delete {
   my ($self, $oid, $cb) = @_;

--- a/lib/Mango/GridFS.pm
+++ b/lib/Mango/GridFS.pm
@@ -132,6 +132,15 @@ Delete file. You can also append a callback to perform operation non-blocking.
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 delete_p
+
+  my $promise = $gridfs->delete_p($oid);
+
+Same as L</"delete">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 find_version
 
   my $oid = $gridfs->find_version('test.txt', 1);
@@ -146,6 +155,15 @@ version. You can also append a callback to perform operation non-blocking.
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 find_version_p
+
+  my $promise = $gridfs->find_version_p($oid);
+
+Same as L</"find_version">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 list
 
   my $names = $gridfs->list;
@@ -157,6 +175,15 @@ List files. You can also append a callback to perform operation non-blocking.
     ...
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
+
+=head2 list_p
+
+  my $promise = $gridfs->list_p;
+
+Same as L</"list">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
 
 =head2 reader
 

--- a/lib/Mango/GridFS/Reader.pm
+++ b/lib/Mango/GridFS/Reader.pm
@@ -182,6 +182,15 @@ Open file. You can also append a callback to perform operation non-blocking.
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 open_p
+
+  my $promise = $reader->open_p;
+
+Same as L</"open">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 read
 
   my $chunk = $reader->read;
@@ -193,6 +202,15 @@ Read chunk. You can also append a callback to perform operation non-blocking.
     ...
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
+
+=head2 read_p
+
+  my $promise = $reader->read_p;
+
+Same as L</"read">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
 
 =head2 seek
 
@@ -218,6 +236,15 @@ operation non-blocking.
     ...
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
+
+=head2 slurp_p
+
+  my $promise = $slurper->slurp_p;
+
+Same as L</"slurp">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
 
 =head2 tell
 

--- a/lib/Mango/GridFS/Reader.pm
+++ b/lib/Mango/GridFS/Reader.pm
@@ -2,8 +2,11 @@ package Mango::GridFS::Reader;
 use Mojo::Base -base;
 
 use Carp 'croak';
+use Mango::Promises;
 
 has 'gridfs';
+
+Mango::Promises->generate_p_methods(qw(open/0 read slurp));
 
 sub chunk_size   { shift->{meta}{chunkSize} }
 sub content_type { shift->{meta}{contentType} }

--- a/lib/Mango/GridFS/Writer.pm
+++ b/lib/Mango/GridFS/Writer.pm
@@ -5,9 +5,12 @@ use Carp 'croak';
 use List::Util 'first';
 use Mango::BSON qw(bson_bin bson_doc bson_oid bson_time);
 use Mojo::IOLoop;
+use Mango::Promises;
 
 has chunk_size => 261120;
 has [qw(content_type filename gridfs metadata)];
+
+Mango::Promises->generate_p_methods(qw(close write/0));
 
 sub close {
   my ($self, $cb) = @_;

--- a/lib/Mango/GridFS/Writer.pm
+++ b/lib/Mango/GridFS/Writer.pm
@@ -190,6 +190,15 @@ Close file. You can also append a callback to perform operation non-blocking.
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
 
+=head2 close_p
+
+  my $promise = $writer->close_p;
+
+Same as L</"close">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+
 =head2 is_closed
 
   my $success = $writer->is_closed;
@@ -207,6 +216,15 @@ Write chunk. You can also append a callback to perform operation non-blocking.
     ...
   });
   Mojo::IOLoop->start unless Mojo::IOLoop->is_running;
+
+=head2 write_p
+
+  my $promise = $writer->write_p;
+
+Same as L</"write">, but performs a non-blocking operation
+and returns a L<Mojo::Promise> object instead of accepting a callback.
+
+Notice that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
 
 =head1 SEE ALSO
 

--- a/lib/Mango/Promises.pm
+++ b/lib/Mango/Promises.pm
@@ -1,0 +1,95 @@
+
+package Mango::Promises;
+
+use Mojo::Base -strict;
+
+use Carp       ();
+use Mojo::Util ();
+
+use constant PROMISES => !!eval { require Mojo::Promise; 1 };
+
+sub generate_p_methods {
+  my ($class, $package) = (shift, scalar caller);
+  my %patch;
+  for (@_) {
+    my ($meth, $arity) = split '/';
+    my $args = ($arity // 1) eq '0' ? '' : '$_[2]';
+    my $code = q[
+      sub {
+        Carp::croak "METHOD\_p() requires Mojo::Promise" unless PROMISES;
+        my $self    = shift;
+        my $promise = Mojo::Promise->new;
+        $self->METHOD(
+          @_ => sub {
+            $_[1] ? $promise->reject($_[1]) : $promise->resolve(ARGS);
+          }
+        );
+        return $promise;
+      }
+    ];
+    s/\bMETHOD\b/$meth/g, s/\bARGS\b/$args/g for $code;
+    $patch{"${meth}_p"} = eval $code;
+  }
+  Mojo::Util::monkey_patch $package, %patch;
+}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+Mango::Promises - Mango with promises
+
+=head1 SYNOPSIS
+
+    use Mango;
+    use feature 'state';
+
+    # Declare a Mango helper
+    sub mango { state $m = Mango->new('mongodb://localhost:27017') }
+
+    # Non-blocking concurrent find
+    my @u = map {
+      mango->db('test')->collection('users')->find_one_p({username => $_})
+    } qw(sri marty);
+    Mojo::Promise->all(@u)->then(
+      sub {
+        say $_->[0]{display_name} for @_;
+      }
+    );
+
+=head1 DESCRIPTION
+
+Since version 1.31, L<Mango> supports non-blocking with promise-returning
+methods. The public interface for this capability are the C<_p> methods
+at L<Mango> and related classes.
+
+L<Mango::Promises> is an internal class that helps to generate and install
+promisified versions of methods into L<Mango> and related classes.
+No user-serviceable parts inside.
+
+Note that promise support depends on L<Mojo::Promise> (L<Mojolicious> 7.53+).
+If L<Mojo::Promise> can't be loaded, every C<_p> method will croak
+with a message such as
+
+    insert_p() requires Mojo::Promise
+
+=begin :private
+
+=head1 METHODS
+
+=head2 generate_p_methods
+
+    Mango::Promises->generate_p_methods(@methods);
+
+This method, I<which is likely to change or go away>, installs into
+the caller package promisified versions of the given methods.
+
+=end :private
+
+=head1 SEE ALSO
+
+L<Mango>, L<Mojo::Promise>.
+
+=cut


### PR DESCRIPTION

This pull request adds promise-returning methods to Mango and related classes as an alternative to non-blocking with callbacks. For this, it relies on Mojo::Promise as introduced with Mojolicious 7.53.

All of Mango continues to work with older Mojolicious as it used to. Only, if Mojo::Promise is not available, the new methods, like `$collection->find_one_p` and `$bulk->execute_p`, don't do anything but to throw exceptions like:

    find_one_p() requires Mojo::Promise

In the same vein, tests cover the new methods if Mojo::Promise is available and, if not, the corresponding tests are ignored.

Most of the patch is repetitive documentation and the new tests. The code change is small, consisting of  a new (internal) helper class Mango::Promises that generate the _p methods from the original methods (like `Mango::Bulk::execute_p` from `Mango::Bulk::execute`) and the inclusion of code like below to each class

```perl
package Mango::Collection;
...
use Mango::Promises;
...
Mango::Promises->generate_p_methods(
  qw(aggregate create/0 drop/0 drop_index/0 ensure_index/0 find_and_modify find_one
    index_information insert map_reduce options remove rename save stats update)
);
```