### PR TITLE
Disable unicode_strings when working with regular expressions

### DIFF
--- a/lib/Mango/BSON.pm
+++ b/lib/Mango/BSON.pm
@@ -216,6 +216,9 @@ sub _decode_value {
     my ($p, $m) = (_decode_cstring($bsonref), _decode_cstring($bsonref));
     croak "invalid regex modifier(s) in 'qr/$p/$m'"
       if length($m) and $m !~ /^[msixpadlun]+\z/;
+    # prevent from injecting qr//u modifier implied by a feature enabled by
+    # Mojolicious 8.50
+    no feature 'unicode_strings';
     # escape $pat to avoid code injection
     return eval "qr/\$p/$m";
   }

--- a/t/bson.t
+++ b/t/bson.t
@@ -12,6 +12,9 @@ sub TO_BSON { {something => shift->something} }
 
 package main;
 use Mojo::Base -strict;
+# prevent from injecting qr//u modifier implied by a feature enabled by
+# Mojolicious 8.50
+no feature 'unicode_strings';
 no warnings 'portable';  # Mango works on 64bits systems only
 
 use Test::More;


### PR DESCRIPTION
Mojo::Base 0.50 enables unicode_strings feature in the scope where it
used from. As a result, deserializing a regular expression injects
qr//u flag to regexp object although the was no such flags in the
deserialized BSON. The same issue repeats in t/bson.t when shuffling
with the regular expressions.

The consequence is that a t/bson.t test fails.

This patch fixes it with disabling unicode_strings feature where
needed.

https://github.com/oliwer/mango/issues/36